### PR TITLE
修复多个问题（3-15）

### DIFF
--- a/library-xwalk/src/main/java/io/sugo/android/xwalk/SugoXWalkViewEventListener.java
+++ b/library-xwalk/src/main/java/io/sugo/android/xwalk/SugoXWalkViewEventListener.java
@@ -51,9 +51,6 @@ public class SugoXWalkViewEventListener extends SugoWebEventListener {
     }
 
     public static void addCurrentXWalkView(XWalkView currentXWalkView) {
-        if (!SugoAPI.developmentMode) {
-            return;
-        }
         sCurrentXWalkView.add(currentXWalkView);
         if (SGConfig.DEBUG) {
             Log.d("SugoWebEventListener", "addCurrentXWalkView : " + currentXWalkView.toString());
@@ -93,6 +90,7 @@ public class SugoXWalkViewEventListener extends SugoWebEventListener {
                     (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && activity.isDestroyed())) {
                 xWalkViewIterator.remove();
                 sugoWNReporter.remove(xWalkView);
+                xWalkView.load("javascript:" + sStayScript, null);
                 if (SGConfig.DEBUG) {
                     Log.d("SugoWebEventListener", "removeXWalkViewReference : " + xWalkView.toString());
                 }

--- a/library/src/main/java/io/sugo/android/mpmetrics/AnalyticsMessages.java
+++ b/library/src/main/java/io/sugo/android/mpmetrics/AnalyticsMessages.java
@@ -187,7 +187,7 @@ import io.sugo.android.viewcrawler.ViewCrawler;
 
     public JSONObject getDefaultEventProperties()
             throws JSONException {
-        if(mSystemInformation == null){
+        if (mSystemInformation == null) {
             mSystemInformation = new SystemInformation(mContext);
         }
         final JSONObject ret = new JSONObject();
@@ -366,12 +366,12 @@ import io.sugo.android.viewcrawler.ViewCrawler;
                         SharedPreferences preferences = mContext.getSharedPreferences(sharedPrefsName, Context.MODE_PRIVATE);
                         final String storeInfo = preferences.getString(ViewCrawler.SHARED_PREF_DIMENSIONS_KEY, null);
                         if (storeInfo == null || storeInfo.equals("") || storeInfo.equals("[]")) {
-                            logAboutMessageToMixpanel("empty dimensions, it do not work !!!");
-                            return;
+                            logAboutMessageToMixpanel("empty dimensions, Flushing do not work !!!");
+                        } else {
+                            logAboutMessageToMixpanel("Flushing queue due to scheduled or forced flush");
+                            updateFlushFrequency();
+                            sendAllData(mDbAdapter);
                         }
-                        logAboutMessageToMixpanel("Flushing queue due to scheduled or forced flush");
-                        updateFlushFrequency();
-                        sendAllData(mDbAdapter);
                         if (SystemClock.elapsedRealtime() >= mDecideRetryAfter) {
                             try {
                                 mDecideChecker.runDecideChecks(getPoster());
@@ -403,9 +403,16 @@ import io.sugo.android.viewcrawler.ViewCrawler;
 
                     ///////////////////////////
                     if ((returnCode >= mConfig.getBulkUploadLimit() || returnCode == MPDbAdapter.DB_OUT_OF_MEMORY_ERROR) && mFailedRetries <= 0) {
-                        logAboutMessageToMixpanel("Flushing queue due to bulk upload limit");
-                        updateFlushFrequency();
-                        sendAllData(mDbAdapter);
+                        final String sharedPrefsName = ViewCrawler.SHARED_PREF_EDITS_FILE + SGConfig.getInstance(mContext).getToken();
+                        SharedPreferences preferences = mContext.getSharedPreferences(sharedPrefsName, Context.MODE_PRIVATE);
+                        final String storeInfo = preferences.getString(ViewCrawler.SHARED_PREF_DIMENSIONS_KEY, null);
+                        if (storeInfo == null || storeInfo.equals("") || storeInfo.equals("[]")) {
+                            logAboutMessageToMixpanel("empty dimensions, Flushing do not work !!!");
+                        } else {
+                            logAboutMessageToMixpanel("Flushing queue due to bulk upload limit");
+                            updateFlushFrequency();
+                            sendAllData(mDbAdapter);
+                        }
                         if (SystemClock.elapsedRealtime() >= mDecideRetryAfter) {
                             try {
                                 mDecideChecker.runDecideChecks(getPoster());

--- a/library/src/main/java/io/sugo/android/mpmetrics/DecideChecker.java
+++ b/library/src/main/java/io/sugo/android/mpmetrics/DecideChecker.java
@@ -73,8 +73,10 @@ import io.sugo.android.util.RemoteService;
             final String distinctId = updates.getDistinctId();
             try {
                 final Result result = runDecideCheck(updates.getToken(), distinctId, poster);
-                updates.reportResults(result.surveys, result.notifications, result.eventBindings,
-                        result.h5EventBindings, result.variants, result.pageInfo, result.dimensions);
+                if(result != null) {
+                    updates.reportResults(result.surveys, result.notifications, result.eventBindings,
+                            result.h5EventBindings, result.variants, result.pageInfo, result.dimensions);
+                }
             } catch (final UnintelligibleMessageException e) {
                 Log.e(LOGTAG, e.getMessage(), e);
             }
@@ -99,6 +101,8 @@ import io.sugo.android.util.RemoteService;
         Result parsed = new Result();
         if (null != responseString) {
             parsed = parseDecideResponse(responseString);
+        } else {
+            return null;
         }
 
         final Iterator<InAppNotification> notificationIterator = parsed.notifications.iterator();

--- a/library/src/main/java/io/sugo/android/mpmetrics/SugoAPI.java
+++ b/library/src/main/java/io/sugo/android/mpmetrics/SugoAPI.java
@@ -1247,7 +1247,7 @@ public class SugoAPI {
         String page = null;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB) {
             Activity activity = fragment.getActivity();
-            page = activity.getPackageName() + "." + activity.getLocalClassName();
+            page = activity.getClass().getCanonicalName();
         } else {
             page = SugoPageManager.getInstance().getCurrentPage(mContext);
         }
@@ -1260,7 +1260,7 @@ public class SugoAPI {
         String page = null;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB) {
             Activity activity = fragment.getActivity();
-            page = activity.getPackageName() + "." + activity.getLocalClassName();
+            page = activity.getClass().getCanonicalName();
         } else {
             page = SugoPageManager.getInstance().getCurrentPage(mContext);
         }
@@ -1273,7 +1273,7 @@ public class SugoAPI {
         String page = null;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB) {
             Activity activity = fragment.getActivity();
-            page = activity.getPackageName() + "." + activity.getLocalClassName();
+            page = activity.getClass().getCanonicalName();
         } else {
             page = SugoPageManager.getInstance().getCurrentPage(mContext);
         }
@@ -1284,7 +1284,7 @@ public class SugoAPI {
         String page = null;
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB) {
             Activity activity = fragment.getActivity();
-            page = activity.getPackageName() + "." + activity.getLocalClassName();
+            page = activity.getClass().getCanonicalName();
         } else {
             page = SugoPageManager.getInstance().getCurrentPage(mContext);
         }

--- a/library/src/main/java/io/sugo/android/mpmetrics/SugoActivityLifecycleCallbacks.java
+++ b/library/src/main/java/io/sugo/android/mpmetrics/SugoActivityLifecycleCallbacks.java
@@ -67,9 +67,9 @@ import io.sugo.android.viewcrawler.GestureTracker;
             // App 从 background 状态回来，是被唤醒
             JSONObject props = new JSONObject();
             try {
-                props.put(SGConfig.FIELD_PAGE, activity.getPackageName() + "." + activity.getLocalClassName());
+                props.put(SGConfig.FIELD_PAGE, activity.getClass().getCanonicalName());
                 props.put(SGConfig.FIELD_PAGE_NAME, SugoPageManager.getInstance()
-                        .getCurrentPageName(activity.getPackageName() + "." + activity.getLocalClassName()));
+                        .getCurrentPageName(activity.getClass().getCanonicalName()));
             } catch (JSONException e) {
                 e.printStackTrace();
             }
@@ -79,9 +79,9 @@ import io.sugo.android.viewcrawler.GestureTracker;
         if (!mDisableActivities.contains(activity)) {
             try {
                 JSONObject props = new JSONObject();
-                props.put(SGConfig.FIELD_PAGE, activity.getPackageName() + "." + activity.getLocalClassName());
+                props.put(SGConfig.FIELD_PAGE, activity.getClass().getCanonicalName());
                 props.put(SGConfig.FIELD_PAGE_NAME, SugoPageManager.getInstance()
-                        .getCurrentPageName(activity.getPackageName() + "." + activity.getLocalClassName()));
+                        .getCurrentPageName(activity.getClass().getCanonicalName()));
                 mMpInstance.track("浏览", props);
                 mMpInstance.timeEvent("窗口停留");
             } catch (JSONException e) {
@@ -108,9 +108,9 @@ import io.sugo.android.viewcrawler.GestureTracker;
                     mIsForeground = false;
                     JSONObject props = new JSONObject();
                     try {
-                        props.put(SGConfig.FIELD_PAGE, activity.getPackageName() + "." + activity.getLocalClassName());
+                        props.put(SGConfig.FIELD_PAGE, activity.getClass().getCanonicalName());
                         props.put(SGConfig.FIELD_PAGE_NAME, SugoPageManager.getInstance()
-                                .getCurrentPageName(activity.getPackageName() + "." + activity.getLocalClassName()));
+                                .getCurrentPageName(activity.getClass().getCanonicalName()));
                     } catch (JSONException e) {
                         e.printStackTrace();
                     }
@@ -122,9 +122,9 @@ import io.sugo.android.viewcrawler.GestureTracker;
         if (!mDisableActivities.contains(activity)) {
             try {
                 JSONObject props = new JSONObject();
-                props.put(SGConfig.FIELD_PAGE, activity.getPackageName() + "." + activity.getLocalClassName());
+                props.put(SGConfig.FIELD_PAGE, activity.getClass().getCanonicalName());
                 props.put(SGConfig.FIELD_PAGE_NAME, SugoPageManager.getInstance()
-                        .getCurrentPageName(activity.getPackageName() + "." + activity.getLocalClassName()));
+                        .getCurrentPageName(activity.getClass().getCanonicalName()));
                 mMpInstance.track("窗口停留", props);
             } catch (JSONException e) {
                 e.printStackTrace();
@@ -138,6 +138,7 @@ import io.sugo.android.viewcrawler.GestureTracker;
 
     @Override
     public void onActivityDestroyed(Activity activity) {
+        // TODO: 2017/3/15 此处有 BUG （比如启动的 Activity 调用第二个 Activity 后 finish 自己 ）
         if (activity.isTaskRoot()) {     // 最后一个被摧毁的 Activity，是应用被退出
             if (mCheckInBackground != null) {
                 mHandler.removeCallbacks(mCheckInBackground);
@@ -146,9 +147,9 @@ import io.sugo.android.viewcrawler.GestureTracker;
 
             JSONObject props = new JSONObject();
             try {
-                props.put(SGConfig.FIELD_PAGE, activity.getPackageName() + "." + activity.getLocalClassName());
+                props.put(SGConfig.FIELD_PAGE, activity.getClass().getCanonicalName());
                 props.put(SGConfig.FIELD_PAGE_NAME, SugoPageManager.getInstance()
-                        .getCurrentPageName(activity.getPackageName() + "." + activity.getLocalClassName()));
+                        .getCurrentPageName(activity.getClass().getCanonicalName()));
             } catch (JSONException e) {
                 e.printStackTrace();
             }

--- a/library/src/main/java/io/sugo/android/mpmetrics/SugoWebEventListener.java
+++ b/library/src/main/java/io/sugo/android/mpmetrics/SugoWebEventListener.java
@@ -26,6 +26,10 @@ public class SugoWebEventListener {
 
     public static Map<Object, SugoWebNodeReporter> sugoWNReporter = new HashMap<Object, SugoWebNodeReporter>();
 
+    protected static final String sStayScript =
+            "var duration = (new Date().getTime() - sugo.enter_time)/1000;\n" +
+                    "sugo.track('停留', {" + SGConfig.FIELD_DURATION + ": duration});\n";
+
     public SugoWebEventListener(SugoAPI sugoAPI) {
         this.sugoAPI = sugoAPI;
     }
@@ -72,9 +76,6 @@ public class SugoWebEventListener {
     }
 
     public static void addCurrentWebView(WebView currentWebView) {
-        if (!SugoAPI.developmentMode) {
-            return;
-        }
         sCurrentWebView.add(currentWebView);
         if (SGConfig.DEBUG) {
             Log.d("SugoWebEventListener", "addCurrentWebView : " + currentWebView.toString());
@@ -115,6 +116,7 @@ public class SugoWebEventListener {
                     (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && activity.isDestroyed())) {
                 webViewIterator.remove();
                 sugoWNReporter.remove(webView);
+                webView.loadUrl("javascript:" + sStayScript);
                 if (SGConfig.DEBUG) {
                     Log.d("SugoWebEventListener", "removeWebViewReference : " + webView.toString());
                 }


### PR DESCRIPTION
1 修复直接退出 Activity 时，缺失的 webview 停留事件
2 当 dimensions 为空的时候，再次请求配置，无需再次启动
3 当配置请求失败的时候，不覆盖当前本地配置
4 禁止获取密码输入类型的 EditText 内容
5 修复部分web页面触发多次注入以及停留遗漏的问题
6 给 init_code 增加 sugo 参数
7 修复获取正确类路径的方式
8 替换路径前缀问题 /data/data/io.sugo.android
9 去掉 url hash 中 ? 以及后面的内容